### PR TITLE
Fix python 3 support

### DIFF
--- a/supervisor_stdout.py
+++ b/supervisor_stdout.py
@@ -18,6 +18,7 @@ def main():
         write_stdout('RESULT %s\n%s'%(len(data), data)) # transition from READY to ACKNOWLEDGED
 
 def event_handler(event, response):
+    response = response.decode()
     line, data = response.split('\n', 1)
     headers = dict([ x.split(':') for x in line.split() ])
     lines = data.split('\n')


### PR DESCRIPTION
Under Python 3, the `response` argument passed to the `event_handler()` function is a `bytes` instance; before using the data from it in string manipulations and print statements, it needs to be transformed to `str`, because the automatic "cast" includes an initial `b` and quotes around the value.
Under Python 2, this is still ok if the logs are all ASCII, but more generally, who cares. Python 2 is dead.

This proposal is courtesy of Matific -- see https://www.matific.com