### PR TITLE
Used splitlines instead of split('\n') because the latter returns a l…

### DIFF
--- a/supervisor_stdout.py
+++ b/supervisor_stdout.py
@@ -19,7 +19,7 @@ def main():
 def event_handler(event, response):
     line, data = response.split('\n', 1)
     headers = dict([ x.split(':') for x in line.split() ])
-    lines = data.split('\n')
+    lines = data.splitlines()
     prefix = '%s %s | '%(headers['processname'], headers['channel'])
     print '\n'.join([ prefix + l for l in lines ])
 


### PR DESCRIPTION
…eading empty

string if the input ends with a newline. This resulted in spurious empty lines in
log because of the buffering.